### PR TITLE
Bump actions-setup-minikube to v2.3.0

### DIFF
--- a/.github/workflows/e2etests.yaml
+++ b/.github/workflows/e2etests.yaml
@@ -20,7 +20,7 @@ jobs:
   local-docker-build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2    
+    - uses: actions/checkout@v2
     - uses: docker/setup-buildx-action@v1
     - name: Build and push to /tmp
       uses: docker/build-push-action@v2
@@ -43,7 +43,7 @@ jobs:
       uses: stefanprodan/kube-tools@v1
       with:
         kubectl: 1.18.2
-        kustomize: 3.5.5    
+        kustomize: 3.5.5
     - run: tests/install/testinstallyaml.sh
 
   test-start-and-finish-handlers:
@@ -65,7 +65,7 @@ jobs:
           docker load --input /tmp/image.tar
           docker image ls -a
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.0.1
+        uses: manusa/actions-setup-minikube@v2.3.0
         with:
           minikube version: 'v1.15.1'
           kubernetes version: 'v1.17.11'
@@ -73,7 +73,7 @@ jobs:
         uses: stefanprodan/kube-tools@v1
         with:
           kubectl: 1.18.2
-          kustomize: 3.5.5     
+          kustomize: 3.5.5
       - run: tests/integration/teststarthandler.sh
       - run: tests/integration/teststarthandler.sh
       - run: tests/integration/cleanupstart.sh
@@ -92,17 +92,17 @@ jobs:
         uses: stefanprodan/kube-tools@v1
         with:
           kubectl: 1.18.2
-          kustomize: 3.5.5    
+          kustomize: 3.5.5
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.0.1
+        uses: manusa/actions-setup-minikube@v2.3.0
         with:
           minikube version: 'v1.15.1'
           kubernetes version: 'v1.17.11'
-      - run: tests/install/checkinstalleverything.sh 
+      - run: tests/install/checkinstalleverything.sh
 
   build-and-push:
     # Ensure test job passes before pushing image.
-    needs: 
+    needs:
     - test-start-and-finish-handlers
     - test-install
 


### PR DESCRIPTION
Upgrade `manusa/actions-setup-minikube` to use the latest version.

GitHub is rolling out Ubuntu 20.04 as the default environment. GitHub actions workflows using `ubuntu-latest` will [soon ](https://github.com/actions/virtual-environments/issues/1816) start an Ubuntu 20,04 instance instead of 18.04.

Prior versions of `manusa/actions-setup-minikube` have a check which won't allow the workflow job to run. Starting on `2.2.0`, Ubuntu 20.04 is supported too (https://github.com/manusa/actions-setup-minikube/issues/26).